### PR TITLE
Reduce performance and memory footprint.

### DIFF
--- a/Xbim.Presentation/WpfMaterial.cs
+++ b/Xbim.Presentation/WpfMaterial.cs
@@ -39,11 +39,13 @@ namespace Xbim.Presentation
                 _description = "Texture " + colour;
                 IsTransparent = colour.IsTransparent;
             }
+            _material.Freeze();
         }
 
         public void CreateMaterial(XbimColour colour)
         {
             _material = MaterialFromColour(colour);
+            _material.Freeze();
         }
 
         private Material MaterialFromColour(XbimColour colour)


### PR DESCRIPTION
To freeze the material removes the need to register for couple WpfMeshGeometry3D with Material by events. This speeds up the initial drawing of the model and reduces the memory footprint.

The effect can only be seen on very large models.