### PR TITLE
Added IfcProperyReferenceValue support for properties pane

### DIFF
--- a/Xbim.Presentation/IfcMetaDataControl.xaml.cs
+++ b/Xbim.Presentation/IfcMetaDataControl.xaml.cs
@@ -423,6 +423,15 @@ namespace Xbim.Presentation
             {
                 AddProperty(item, pSet.Name);
             }
+            foreach (var item in pSet.HasProperties.OfType<IIfcPropertyReferenceValue>()) // handle IfcPropertyReferenceValue
+            {
+                switch (item.PropertyReference.GetType().Name)
+                {
+                    case "IfcIrregularTimeSeries":
+                        AddProperty((IIfcIrregularTimeSeries)item.PropertyReference, pSet.Name);
+                        break;
+                }
+            }
         }
 
         private void AddProperty(IIfcPropertyEnumeratedValue item, string groupName)
@@ -456,6 +465,19 @@ namespace Xbim.Presentation
                 Name = item.Name,
                 Value = val
             });
+        }
+        private void AddProperty(IIfcIrregularTimeSeries item, string groupName)
+        {
+            foreach (var value in item.Values)
+            {
+                _properties.Add(new PropertyItem
+                {
+                    IfcLabel = value.EntityLabel,
+                    PropertySetName = groupName + " / " + item.Name,
+                    Name = value.TimeStamp,
+                    Value = string.Join(", ",value.ListValues)
+                }); 
+            }
         }
 
         private void FillMaterialData()


### PR DESCRIPTION
![capture](https://user-images.githubusercontent.com/1928970/40750454-c69e07e4-643d-11e8-9c9d-8f35728bb211.PNG)

Have currently only implemented IfcIrregularTimeSeries and IfcIrregularTimeSeriesValues but plan to support all of IfcObjectReferenceSelect types : IfcMaterialDefinition, IfcPerson, IfcOrganization, IfcPersonAndOrganization, IfcExternalReference, IfcTimeSeries, IfcAddress, IfcAppliedValue, IfcTable.

**This:**
```cs
switch (item.PropertyReference.GetType().Name)
{
     case "IfcIrregularTimeSeries":
         AddProperty((IIfcIrregularTimeSeries)item.PropertyReference, pSet.Name);
         break;
}
```
Feels hackish and inellegant. If you can recommend a better way of sorting based on the type returned by .PropertyReference please let me know and I'll use that going forward.