### PR TITLE
Update grid enhancement

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,13 +16,13 @@
     <Authors>Steve Lockley, Martin Cerny and XBIMTeam Contributors</Authors>
     <Product>XBIM WindowsUI</Product>
     <PackageLicenseExpression>CDDL-1.0</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/xBimTeam/XbimCobieExpress</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/xBimTeam/XbimWindowsUI</PackageProjectUrl>
     <PackageIconUrl>https://avatars1.githubusercontent.com/u/2284875?v=3&amp;amp;s=240</PackageIconUrl>
     <PackageReleaseNotes>
       Now built on XBIM v5. Migrated from log4net to Microsoft.Extensions.Logging.
     </PackageReleaseNotes>
     <PackageTags>BIM, IFC, IfcXml, IfcZip, Ifc4, COBie, BuildingSmart</PackageTags>
-    <RepositoryUrl>https://github.com/xBimTeam/XbimEssentials/tree/master</RepositoryUrl>
+    <RepositoryUrl>https://github.com/xBimTeam/XbimWindowsUI/tree/master</RepositoryUrl>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>

--- a/Xbim.Presentation/DrawingControl3D.xaml.cs
+++ b/Xbim.Presentation/DrawingControl3D.xaml.cs
@@ -1449,29 +1449,41 @@ namespace Xbim.Presentation
         /// </summary>
         private void UpdateGrid()
         {
-            GridLines.Visible = !_hasModelGrid;
-            var gridSizeX = Math.Ceiling(_viewBounds.SizeX/10)*10;
-            var gridSizeY = Math.Ceiling(_viewBounds.SizeY/10)*10;
+            // Disable while updating
+            GridLines.Visible = false;
 
-            GridLines.Length = gridSizeX;
-            GridLines.Width = gridSizeY;
+            var gridSizeX = Math.Ceiling(_viewBounds.SizeX / 10) * 10;
+            var gridSizeY = Math.Ceiling(_viewBounds.SizeY / 10) * 10;
+
+            GridLines.Length = 1;
+            double gridLevel = Math.Ceiling(Math.Max(gridSizeX, gridSizeY) / 1000);
 
             if (gridSizeX > 10 || gridSizeY > 10)
             {
-                GridLines.MinorDistance = 5;
-                GridLines.MajorDistance = 50;
-                GridLines.Thickness = 0.05;
+                // Being adaptive beyond 10x10
+                GridLines.MinorDistance = gridLevel * 5;
+                GridLines.MajorDistance = gridLevel * 50;
+                GridLines.Thickness = gridLevel * 0.05;
             }
             else
             {
+                // Otherwise static
                 GridLines.MinorDistance = 1;
                 GridLines.MajorDistance = 10;
                 GridLines.Thickness = 0.01;
             }
 
+            // Set extent finally
+            GridLines.Length = gridSizeX;
+            GridLines.Width = gridSizeY;
+
             var p3D = _viewBounds.Centroid();
             var t3D = new TranslateTransform3D(p3D.X, p3D.Y, _viewBounds.Z);
+
             GridLines.Transform = t3D;
+
+            // Show if needed
+            GridLines.Visible = !_hasModelGrid;
         }
 
         public void ReportData(StringBuilder sb, IModel model, int entityLabel)

--- a/Xbim.Presentation/Xbim.Presentation.csproj
+++ b/Xbim.Presentation/Xbim.Presentation.csproj
@@ -26,8 +26,8 @@
   <ItemGroup>
     <PackageReference Include="HelixToolkit.Wpf" Version="2015.1.715" />
     <PackageReference Include="PropertyTools.Wpf" Version="2015.1.66" />
-    <PackageReference Include="Xbim.Essentials" Version="5.0.241-develop" />
-	<PackageReference Include="Xbim.Geometry" Version="5.0.209-develop" />
+    <PackageReference Include="Xbim.Essentials" Version="5.0.252-develop" />
+	<PackageReference Include="Xbim.Geometry" Version="5.0.213-develop" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/Xbim.Presentation/Xbim.Presentation.csproj
+++ b/Xbim.Presentation/Xbim.Presentation.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="HelixToolkit.Wpf" Version="2015.1.715" />
     <PackageReference Include="PropertyTools.Wpf" Version="2015.1.66" />
     <PackageReference Include="Xbim.Essentials" Version="5.0.241-develop" />
-	<PackageReference Include="Xbim.Geometry" Version="5.0.203-develop" />
+	<PackageReference Include="Xbim.Geometry" Version="5.0.209-develop" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/Xbim.WinformsSample/Xbim.WinformsSample.csproj
+++ b/Xbim.WinformsSample/Xbim.WinformsSample.csproj
@@ -123,31 +123,31 @@
     <Reference Include="WindowsBase" />
     <Reference Include="WindowsFormsIntegration" />
     <Reference Include="Xbim.Common, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Common.5.0.250-develop\lib\net47\Xbim.Common.dll</HintPath>
+      <HintPath>..\packages\Xbim.Common.5.0.252-develop\lib\net47\Xbim.Common.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Geometry.Engine.Interop, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Geometry.Engine.Interop.5.0.209-develop\lib\net47\Xbim.Geometry.Engine.Interop.dll</HintPath>
+      <HintPath>..\packages\Xbim.Geometry.Engine.Interop.5.0.213-develop\lib\net47\Xbim.Geometry.Engine.Interop.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Ifc, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Ifc.5.0.250-develop\lib\net47\Xbim.Ifc.dll</HintPath>
+      <HintPath>..\packages\Xbim.Ifc.5.0.252-develop\lib\net47\Xbim.Ifc.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Ifc2x3, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Ifc2x3.5.0.250-develop\lib\net47\Xbim.Ifc2x3.dll</HintPath>
+      <HintPath>..\packages\Xbim.Ifc2x3.5.0.252-develop\lib\net47\Xbim.Ifc2x3.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Ifc4, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Ifc4.5.0.250-develop\lib\net47\Xbim.Ifc4.dll</HintPath>
+      <HintPath>..\packages\Xbim.Ifc4.5.0.252-develop\lib\net47\Xbim.Ifc4.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.IO.Esent, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.IO.Esent.5.0.241-develop\lib\net47\Xbim.IO.Esent.dll</HintPath>
+      <HintPath>..\packages\Xbim.IO.Esent.5.0.252-develop\lib\net47\Xbim.IO.Esent.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.IO.MemoryModel, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.IO.MemoryModel.5.0.250-develop\lib\net47\Xbim.IO.MemoryModel.dll</HintPath>
+      <HintPath>..\packages\Xbim.IO.MemoryModel.5.0.252-develop\lib\net47\Xbim.IO.MemoryModel.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.ModelGeometry.Scene, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.ModelGeometry.Scene.5.0.209-develop\lib\net47\Xbim.ModelGeometry.Scene.dll</HintPath>
+      <HintPath>..\packages\Xbim.ModelGeometry.Scene.5.0.213-develop\lib\net47\Xbim.ModelGeometry.Scene.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Tessellator, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Tessellator.5.0.250-develop\lib\net47\Xbim.Tessellator.dll</HintPath>
+      <HintPath>..\packages\Xbim.Tessellator.5.0.252-develop\lib\net47\Xbim.Tessellator.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -204,12 +204,12 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Xbim.Geometry.Engine.Interop.5.0.209-develop\build\net47\Xbim.Geometry.Engine.Interop.targets" Condition="Exists('..\packages\Xbim.Geometry.Engine.Interop.5.0.209-develop\build\net47\Xbim.Geometry.Engine.Interop.targets')" />
+  <Import Project="..\packages\Xbim.Geometry.Engine.Interop.5.0.213-develop\build\net47\Xbim.Geometry.Engine.Interop.targets" Condition="Exists('..\packages\Xbim.Geometry.Engine.Interop.5.0.213-develop\build\net47\Xbim.Geometry.Engine.Interop.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Xbim.Geometry.Engine.Interop.5.0.209-develop\build\net47\Xbim.Geometry.Engine.Interop.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xbim.Geometry.Engine.Interop.5.0.209-develop\build\net47\Xbim.Geometry.Engine.Interop.targets'))" />
+    <Error Condition="!Exists('..\packages\Xbim.Geometry.Engine.Interop.5.0.213-develop\build\net47\Xbim.Geometry.Engine.Interop.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xbim.Geometry.Engine.Interop.5.0.213-develop\build\net47\Xbim.Geometry.Engine.Interop.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Xbim.WinformsSample/Xbim.WinformsSample.csproj
+++ b/Xbim.WinformsSample/Xbim.WinformsSample.csproj
@@ -123,31 +123,31 @@
     <Reference Include="WindowsBase" />
     <Reference Include="WindowsFormsIntegration" />
     <Reference Include="Xbim.Common, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Common.5.0.241-develop\lib\net47\Xbim.Common.dll</HintPath>
+      <HintPath>..\packages\Xbim.Common.5.0.250-develop\lib\net47\Xbim.Common.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Geometry.Engine.Interop, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Geometry.Engine.Interop.5.0.203-develop\lib\net47\Xbim.Geometry.Engine.Interop.dll</HintPath>
+      <HintPath>..\packages\Xbim.Geometry.Engine.Interop.5.0.209-develop\lib\net47\Xbim.Geometry.Engine.Interop.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Ifc, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Ifc.5.0.241-develop\lib\net47\Xbim.Ifc.dll</HintPath>
+      <HintPath>..\packages\Xbim.Ifc.5.0.250-develop\lib\net47\Xbim.Ifc.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Ifc2x3, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Ifc2x3.5.0.241-develop\lib\net47\Xbim.Ifc2x3.dll</HintPath>
+      <HintPath>..\packages\Xbim.Ifc2x3.5.0.250-develop\lib\net47\Xbim.Ifc2x3.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Ifc4, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Ifc4.5.0.241-develop\lib\net47\Xbim.Ifc4.dll</HintPath>
+      <HintPath>..\packages\Xbim.Ifc4.5.0.250-develop\lib\net47\Xbim.Ifc4.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.IO.Esent, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
       <HintPath>..\packages\Xbim.IO.Esent.5.0.241-develop\lib\net47\Xbim.IO.Esent.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.IO.MemoryModel, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.IO.MemoryModel.5.0.241-develop\lib\net47\Xbim.IO.MemoryModel.dll</HintPath>
+      <HintPath>..\packages\Xbim.IO.MemoryModel.5.0.250-develop\lib\net47\Xbim.IO.MemoryModel.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.ModelGeometry.Scene, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.ModelGeometry.Scene.5.0.203-develop\lib\net47\Xbim.ModelGeometry.Scene.dll</HintPath>
+      <HintPath>..\packages\Xbim.ModelGeometry.Scene.5.0.209-develop\lib\net47\Xbim.ModelGeometry.Scene.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Tessellator, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Tessellator.5.0.241-develop\lib\net47\Xbim.Tessellator.dll</HintPath>
+      <HintPath>..\packages\Xbim.Tessellator.5.0.250-develop\lib\net47\Xbim.Tessellator.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -204,12 +204,12 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Xbim.Geometry.Engine.Interop.5.0.203-develop\build\net47\Xbim.Geometry.Engine.Interop.targets" Condition="Exists('..\packages\Xbim.Geometry.Engine.Interop.5.0.203-develop\build\net47\Xbim.Geometry.Engine.Interop.targets')" />
+  <Import Project="..\packages\Xbim.Geometry.Engine.Interop.5.0.209-develop\build\net47\Xbim.Geometry.Engine.Interop.targets" Condition="Exists('..\packages\Xbim.Geometry.Engine.Interop.5.0.209-develop\build\net47\Xbim.Geometry.Engine.Interop.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Xbim.Geometry.Engine.Interop.5.0.203-develop\build\net47\Xbim.Geometry.Engine.Interop.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xbim.Geometry.Engine.Interop.5.0.203-develop\build\net47\Xbim.Geometry.Engine.Interop.targets'))" />
+    <Error Condition="!Exists('..\packages\Xbim.Geometry.Engine.Interop.5.0.209-develop\build\net47\Xbim.Geometry.Engine.Interop.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xbim.Geometry.Engine.Interop.5.0.209-develop\build\net47\Xbim.Geometry.Engine.Interop.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Xbim.WinformsSample/packages.config
+++ b/Xbim.WinformsSample/packages.config
@@ -20,15 +20,15 @@
   <package id="System.Numerics.Vectors" version="4.4.0" targetFramework="net47" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.1" targetFramework="net47" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net47" />
-  <package id="Xbim.Common" version="5.0.241-develop" targetFramework="net47" />
+  <package id="Xbim.Common" version="5.0.250-develop" targetFramework="net47" />
   <package id="Xbim.Essentials" version="5.0.241-develop" targetFramework="net47" />
-  <package id="Xbim.Geometry" version="5.0.203-develop" targetFramework="net47" />
-  <package id="Xbim.Geometry.Engine.Interop" version="5.0.203-develop" targetFramework="net47" />
-  <package id="Xbim.Ifc" version="5.0.241-develop" targetFramework="net47" />
-  <package id="Xbim.Ifc2x3" version="5.0.241-develop" targetFramework="net47" />
-  <package id="Xbim.Ifc4" version="5.0.241-develop" targetFramework="net47" />
+  <package id="Xbim.Geometry" version="5.0.209-develop" targetFramework="net47" />
+  <package id="Xbim.Geometry.Engine.Interop" version="5.0.209-develop" targetFramework="net47" />
+  <package id="Xbim.Ifc" version="5.0.250-develop" targetFramework="net47" />
+  <package id="Xbim.Ifc2x3" version="5.0.250-develop" targetFramework="net47" />
+  <package id="Xbim.Ifc4" version="5.0.250-develop" targetFramework="net47" />
   <package id="Xbim.IO.Esent" version="5.0.241-develop" targetFramework="net47" />
-  <package id="Xbim.IO.MemoryModel" version="5.0.241-develop" targetFramework="net47" />
-  <package id="Xbim.ModelGeometry.Scene" version="5.0.203-develop" targetFramework="net47" />
-  <package id="Xbim.Tessellator" version="5.0.241-develop" targetFramework="net47" />
+  <package id="Xbim.IO.MemoryModel" version="5.0.250-develop" targetFramework="net47" />
+  <package id="Xbim.ModelGeometry.Scene" version="5.0.209-develop" targetFramework="net47" />
+  <package id="Xbim.Tessellator" version="5.0.250-develop" targetFramework="net47" />
 </packages>

--- a/Xbim.WinformsSample/packages.config
+++ b/Xbim.WinformsSample/packages.config
@@ -20,15 +20,15 @@
   <package id="System.Numerics.Vectors" version="4.4.0" targetFramework="net47" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.1" targetFramework="net47" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net47" />
-  <package id="Xbim.Common" version="5.0.250-develop" targetFramework="net47" />
-  <package id="Xbim.Essentials" version="5.0.241-develop" targetFramework="net47" />
-  <package id="Xbim.Geometry" version="5.0.209-develop" targetFramework="net47" />
-  <package id="Xbim.Geometry.Engine.Interop" version="5.0.209-develop" targetFramework="net47" />
-  <package id="Xbim.Ifc" version="5.0.250-develop" targetFramework="net47" />
-  <package id="Xbim.Ifc2x3" version="5.0.250-develop" targetFramework="net47" />
-  <package id="Xbim.Ifc4" version="5.0.250-develop" targetFramework="net47" />
-  <package id="Xbim.IO.Esent" version="5.0.241-develop" targetFramework="net47" />
-  <package id="Xbim.IO.MemoryModel" version="5.0.250-develop" targetFramework="net47" />
-  <package id="Xbim.ModelGeometry.Scene" version="5.0.209-develop" targetFramework="net47" />
-  <package id="Xbim.Tessellator" version="5.0.250-develop" targetFramework="net47" />
+  <package id="Xbim.Common" version="5.0.252-develop" targetFramework="net47" />
+  <package id="Xbim.Essentials" version="5.0.252-develop" targetFramework="net47" />
+  <package id="Xbim.Geometry" version="5.0.213-develop" targetFramework="net47" />
+  <package id="Xbim.Geometry.Engine.Interop" version="5.0.213-develop" targetFramework="net47" />
+  <package id="Xbim.Ifc" version="5.0.252-develop" targetFramework="net47" />
+  <package id="Xbim.Ifc2x3" version="5.0.252-develop" targetFramework="net47" />
+  <package id="Xbim.Ifc4" version="5.0.252-develop" targetFramework="net47" />
+  <package id="Xbim.IO.Esent" version="5.0.252-develop" targetFramework="net47" />
+  <package id="Xbim.IO.MemoryModel" version="5.0.252-develop" targetFramework="net47" />
+  <package id="Xbim.ModelGeometry.Scene" version="5.0.213-develop" targetFramework="net47" />
+  <package id="Xbim.Tessellator" version="5.0.252-develop" targetFramework="net47" />
 </packages>

--- a/XbimXplorer/XbimXplorer.csproj
+++ b/XbimXplorer/XbimXplorer.csproj
@@ -52,8 +52,8 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />
     <PackageReference Include="SharpZipLib" Version="0.86.0" />
-    <PackageReference Include="Xbim.Essentials" Version="5.0.241-develop" />
-    <PackageReference Include="Xbim.Geometry" Version="5.0.209-develop" />
+    <PackageReference Include="Xbim.Essentials" Version="5.0.252-develop" />
+    <PackageReference Include="Xbim.Geometry" Version="5.0.213-develop" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/XbimXplorer/XbimXplorer.csproj
+++ b/XbimXplorer/XbimXplorer.csproj
@@ -53,7 +53,7 @@
     <PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />
     <PackageReference Include="SharpZipLib" Version="0.86.0" />
     <PackageReference Include="Xbim.Essentials" Version="5.0.241-develop" />
-    <PackageReference Include="Xbim.Geometry" Version="5.0.203-develop" />
+    <PackageReference Include="Xbim.Geometry" Version="5.0.209-develop" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/XplorerPlugin.Bcf/XplorerPlugin.Bcf.csproj
+++ b/XplorerPlugin.Bcf/XplorerPlugin.Bcf.csproj
@@ -136,31 +136,31 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="Xbim.Common, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Common.5.0.250-develop\lib\net47\Xbim.Common.dll</HintPath>
+      <HintPath>..\packages\Xbim.Common.5.0.252-develop\lib\net47\Xbim.Common.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Geometry.Engine.Interop, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Geometry.Engine.Interop.5.0.209-develop\lib\net47\Xbim.Geometry.Engine.Interop.dll</HintPath>
+      <HintPath>..\packages\Xbim.Geometry.Engine.Interop.5.0.213-develop\lib\net47\Xbim.Geometry.Engine.Interop.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Ifc, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Ifc.5.0.250-develop\lib\net47\Xbim.Ifc.dll</HintPath>
+      <HintPath>..\packages\Xbim.Ifc.5.0.252-develop\lib\net47\Xbim.Ifc.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Ifc2x3, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Ifc2x3.5.0.250-develop\lib\net47\Xbim.Ifc2x3.dll</HintPath>
+      <HintPath>..\packages\Xbim.Ifc2x3.5.0.252-develop\lib\net47\Xbim.Ifc2x3.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Ifc4, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Ifc4.5.0.250-develop\lib\net47\Xbim.Ifc4.dll</HintPath>
+      <HintPath>..\packages\Xbim.Ifc4.5.0.252-develop\lib\net47\Xbim.Ifc4.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.IO.Esent, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.IO.Esent.5.0.241-develop\lib\net47\Xbim.IO.Esent.dll</HintPath>
+      <HintPath>..\packages\Xbim.IO.Esent.5.0.252-develop\lib\net47\Xbim.IO.Esent.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.IO.MemoryModel, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.IO.MemoryModel.5.0.250-develop\lib\net47\Xbim.IO.MemoryModel.dll</HintPath>
+      <HintPath>..\packages\Xbim.IO.MemoryModel.5.0.252-develop\lib\net47\Xbim.IO.MemoryModel.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.ModelGeometry.Scene, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.ModelGeometry.Scene.5.0.209-develop\lib\net47\Xbim.ModelGeometry.Scene.dll</HintPath>
+      <HintPath>..\packages\Xbim.ModelGeometry.Scene.5.0.213-develop\lib\net47\Xbim.ModelGeometry.Scene.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Tessellator, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Tessellator.5.0.250-develop\lib\net47\Xbim.Tessellator.dll</HintPath>
+      <HintPath>..\packages\Xbim.Tessellator.5.0.252-develop\lib\net47\Xbim.Tessellator.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -266,12 +266,12 @@
     </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Xbim.Geometry.Engine.Interop.5.0.209-develop\build\net47\Xbim.Geometry.Engine.Interop.targets" Condition="Exists('..\packages\Xbim.Geometry.Engine.Interop.5.0.209-develop\build\net47\Xbim.Geometry.Engine.Interop.targets')" />
+  <Import Project="..\packages\Xbim.Geometry.Engine.Interop.5.0.213-develop\build\net47\Xbim.Geometry.Engine.Interop.targets" Condition="Exists('..\packages\Xbim.Geometry.Engine.Interop.5.0.213-develop\build\net47\Xbim.Geometry.Engine.Interop.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Xbim.Geometry.Engine.Interop.5.0.209-develop\build\net47\Xbim.Geometry.Engine.Interop.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xbim.Geometry.Engine.Interop.5.0.209-develop\build\net47\Xbim.Geometry.Engine.Interop.targets'))" />
+    <Error Condition="!Exists('..\packages\Xbim.Geometry.Engine.Interop.5.0.213-develop\build\net47\Xbim.Geometry.Engine.Interop.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xbim.Geometry.Engine.Interop.5.0.213-develop\build\net47\Xbim.Geometry.Engine.Interop.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/XplorerPlugin.Bcf/XplorerPlugin.Bcf.csproj
+++ b/XplorerPlugin.Bcf/XplorerPlugin.Bcf.csproj
@@ -136,31 +136,31 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="Xbim.Common, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Common.5.0.241-develop\lib\net47\Xbim.Common.dll</HintPath>
+      <HintPath>..\packages\Xbim.Common.5.0.250-develop\lib\net47\Xbim.Common.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Geometry.Engine.Interop, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Geometry.Engine.Interop.5.0.203-develop\lib\net47\Xbim.Geometry.Engine.Interop.dll</HintPath>
+      <HintPath>..\packages\Xbim.Geometry.Engine.Interop.5.0.209-develop\lib\net47\Xbim.Geometry.Engine.Interop.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Ifc, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Ifc.5.0.241-develop\lib\net47\Xbim.Ifc.dll</HintPath>
+      <HintPath>..\packages\Xbim.Ifc.5.0.250-develop\lib\net47\Xbim.Ifc.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Ifc2x3, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Ifc2x3.5.0.241-develop\lib\net47\Xbim.Ifc2x3.dll</HintPath>
+      <HintPath>..\packages\Xbim.Ifc2x3.5.0.250-develop\lib\net47\Xbim.Ifc2x3.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Ifc4, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Ifc4.5.0.241-develop\lib\net47\Xbim.Ifc4.dll</HintPath>
+      <HintPath>..\packages\Xbim.Ifc4.5.0.250-develop\lib\net47\Xbim.Ifc4.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.IO.Esent, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
       <HintPath>..\packages\Xbim.IO.Esent.5.0.241-develop\lib\net47\Xbim.IO.Esent.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.IO.MemoryModel, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.IO.MemoryModel.5.0.241-develop\lib\net47\Xbim.IO.MemoryModel.dll</HintPath>
+      <HintPath>..\packages\Xbim.IO.MemoryModel.5.0.250-develop\lib\net47\Xbim.IO.MemoryModel.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.ModelGeometry.Scene, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.ModelGeometry.Scene.5.0.203-develop\lib\net47\Xbim.ModelGeometry.Scene.dll</HintPath>
+      <HintPath>..\packages\Xbim.ModelGeometry.Scene.5.0.209-develop\lib\net47\Xbim.ModelGeometry.Scene.dll</HintPath>
     </Reference>
     <Reference Include="Xbim.Tessellator, Version=5.0.0.0, Culture=neutral, PublicKeyToken=11e3655e576ec5a9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xbim.Tessellator.5.0.241-develop\lib\net47\Xbim.Tessellator.dll</HintPath>
+      <HintPath>..\packages\Xbim.Tessellator.5.0.250-develop\lib\net47\Xbim.Tessellator.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -266,12 +266,12 @@
     </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Xbim.Geometry.Engine.Interop.5.0.203-develop\build\net47\Xbim.Geometry.Engine.Interop.targets" Condition="Exists('..\packages\Xbim.Geometry.Engine.Interop.5.0.203-develop\build\net47\Xbim.Geometry.Engine.Interop.targets')" />
+  <Import Project="..\packages\Xbim.Geometry.Engine.Interop.5.0.209-develop\build\net47\Xbim.Geometry.Engine.Interop.targets" Condition="Exists('..\packages\Xbim.Geometry.Engine.Interop.5.0.209-develop\build\net47\Xbim.Geometry.Engine.Interop.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Xbim.Geometry.Engine.Interop.5.0.203-develop\build\net47\Xbim.Geometry.Engine.Interop.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xbim.Geometry.Engine.Interop.5.0.203-develop\build\net47\Xbim.Geometry.Engine.Interop.targets'))" />
+    <Error Condition="!Exists('..\packages\Xbim.Geometry.Engine.Interop.5.0.209-develop\build\net47\Xbim.Geometry.Engine.Interop.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xbim.Geometry.Engine.Interop.5.0.209-develop\build\net47\Xbim.Geometry.Engine.Interop.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/XplorerPlugin.Bcf/packages.config
+++ b/XplorerPlugin.Bcf/packages.config
@@ -19,15 +19,15 @@
   <package id="System.Numerics.Vectors" version="4.4.0" targetFramework="net47" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.1" targetFramework="net47" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net47" />
-  <package id="Xbim.Common" version="5.0.241-develop" targetFramework="net47" />
+  <package id="Xbim.Common" version="5.0.250-develop" targetFramework="net47" />
   <package id="Xbim.Essentials" version="5.0.241-develop" targetFramework="net47" />
-  <package id="Xbim.Geometry" version="5.0.203-develop" targetFramework="net47" />
-  <package id="Xbim.Geometry.Engine.Interop" version="5.0.203-develop" targetFramework="net47" />
-  <package id="Xbim.Ifc" version="5.0.241-develop" targetFramework="net47" />
-  <package id="Xbim.Ifc2x3" version="5.0.241-develop" targetFramework="net47" />
-  <package id="Xbim.Ifc4" version="5.0.241-develop" targetFramework="net47" />
+  <package id="Xbim.Geometry" version="5.0.209-develop" targetFramework="net47" />
+  <package id="Xbim.Geometry.Engine.Interop" version="5.0.209-develop" targetFramework="net47" />
+  <package id="Xbim.Ifc" version="5.0.250-develop" targetFramework="net47" />
+  <package id="Xbim.Ifc2x3" version="5.0.250-develop" targetFramework="net47" />
+  <package id="Xbim.Ifc4" version="5.0.250-develop" targetFramework="net47" />
   <package id="Xbim.IO.Esent" version="5.0.241-develop" targetFramework="net47" />
-  <package id="Xbim.IO.MemoryModel" version="5.0.241-develop" targetFramework="net47" />
-  <package id="Xbim.ModelGeometry.Scene" version="5.0.203-develop" targetFramework="net47" />
-  <package id="Xbim.Tessellator" version="5.0.241-develop" targetFramework="net47" />
+  <package id="Xbim.IO.MemoryModel" version="5.0.250-develop" targetFramework="net47" />
+  <package id="Xbim.ModelGeometry.Scene" version="5.0.209-develop" targetFramework="net47" />
+  <package id="Xbim.Tessellator" version="5.0.250-develop" targetFramework="net47" />
 </packages>

--- a/XplorerPlugin.Bcf/packages.config
+++ b/XplorerPlugin.Bcf/packages.config
@@ -19,15 +19,15 @@
   <package id="System.Numerics.Vectors" version="4.4.0" targetFramework="net47" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.1" targetFramework="net47" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net47" />
-  <package id="Xbim.Common" version="5.0.250-develop" targetFramework="net47" />
-  <package id="Xbim.Essentials" version="5.0.241-develop" targetFramework="net47" />
-  <package id="Xbim.Geometry" version="5.0.209-develop" targetFramework="net47" />
-  <package id="Xbim.Geometry.Engine.Interop" version="5.0.209-develop" targetFramework="net47" />
-  <package id="Xbim.Ifc" version="5.0.250-develop" targetFramework="net47" />
-  <package id="Xbim.Ifc2x3" version="5.0.250-develop" targetFramework="net47" />
-  <package id="Xbim.Ifc4" version="5.0.250-develop" targetFramework="net47" />
-  <package id="Xbim.IO.Esent" version="5.0.241-develop" targetFramework="net47" />
-  <package id="Xbim.IO.MemoryModel" version="5.0.250-develop" targetFramework="net47" />
-  <package id="Xbim.ModelGeometry.Scene" version="5.0.209-develop" targetFramework="net47" />
-  <package id="Xbim.Tessellator" version="5.0.250-develop" targetFramework="net47" />
+  <package id="Xbim.Common" version="5.0.252-develop" targetFramework="net47" />
+  <package id="Xbim.Essentials" version="5.0.252-develop" targetFramework="net47" />
+  <package id="Xbim.Geometry" version="5.0.213-develop" targetFramework="net47" />
+  <package id="Xbim.Geometry.Engine.Interop" version="5.0.213-develop" targetFramework="net47" />
+  <package id="Xbim.Ifc" version="5.0.252-develop" targetFramework="net47" />
+  <package id="Xbim.Ifc2x3" version="5.0.252-develop" targetFramework="net47" />
+  <package id="Xbim.Ifc4" version="5.0.252-develop" targetFramework="net47" />
+  <package id="Xbim.IO.Esent" version="5.0.252-develop" targetFramework="net47" />
+  <package id="Xbim.IO.MemoryModel" version="5.0.252-develop" targetFramework="net47" />
+  <package id="Xbim.ModelGeometry.Scene" version="5.0.213-develop" targetFramework="net47" />
+  <package id="Xbim.Tessellator" version="5.0.252-develop" targetFramework="net47" />
 </packages>


### PR DESCRIPTION
An enhancement and fix for update grid logic.

In some cases if the grid extent differs extremely, an OutOfMemoryException is thrown since the adaption is done on a visible grid. So this fix disables the grid first and enables it once everything is in place.

Additonally I've added a (being honest too hard-coded) scaling of the grid size which works according to the extent of the bounding box.