### PR TITLE
Replaced ICSharp zip lib with DotNetZip

### DIFF
--- a/Xbim.WinformsSample/Xbim.WinformsSample.csproj
+++ b/Xbim.WinformsSample/Xbim.WinformsSample.csproj
@@ -50,9 +50,6 @@
     <Reference Include="HelixToolkit.Wpf, Version=2015.1.715.0, Culture=neutral, PublicKeyToken=52aa3500039caf0d, processorArchitecture=MSIL">
       <HintPath>..\packages\HelixToolkit.Wpf.2015.1.715\lib\net45\HelixToolkit.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="ICSharpCode.SharpZipLib, Version=1.1.0.145, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpZipLib.1.1.0\lib\net45\ICSharpCode.SharpZipLib.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Extensions.Configuration, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.Configuration.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Configuration.dll</HintPath>
     </Reference>

--- a/Xbim.WinformsSample/packages.config
+++ b/Xbim.WinformsSample/packages.config
@@ -13,7 +13,6 @@
   <package id="Microsoft.Extensions.Primitives" version="2.1.1" targetFramework="net47" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net47" />
   <package id="PropertyTools.Wpf" version="2015.1.66" targetFramework="net47" />
-  <package id="SharpZipLib" version="1.1.0" targetFramework="net47" />
   <package id="System.Buffers" version="4.5.0" targetFramework="net47" />
   <package id="System.Configuration.ConfigurationManager" version="4.5.0" targetFramework="net47" />
   <package id="System.Memory" version="4.5.3" targetFramework="net47" />

--- a/XbimXplorer/XbimXplorer.csproj
+++ b/XbimXplorer/XbimXplorer.csproj
@@ -45,13 +45,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AvalonDock" Version="2.0.2000" />
+    <PackageReference Include="DotNetZip" Version="1.13.3" />
     <PackageReference Include="HelixToolkit.Wpf" Version="2015.1.715" />
     <PackageReference Include="Nuget.Core" Version="2.14.0" />
     <PackageReference Include="PropertyTools.Wpf" Version="2015.1.66" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.4" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />
-    <PackageReference Include="SharpZipLib" Version="1.1.0" />
     <PackageReference Include="Xbim.Essentials" Version="5.1.259" />
     <PackageReference Include="Xbim.Geometry" Version="5.1.239" />
   </ItemGroup>

--- a/XplorerPlugin.Bcf/XplorerPlugin.Bcf.csproj
+++ b/XplorerPlugin.Bcf/XplorerPlugin.Bcf.csproj
@@ -76,9 +76,6 @@
       <HintPath>..\packages\HelixToolkit.Wpf.2015.1.715\lib\net45\HelixToolkit.Wpf.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ICSharpCode.SharpZipLib, Version=1.1.0.145, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpZipLib.1.1.0\lib\net45\ICSharpCode.SharpZipLib.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Extensions.Configuration, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.Configuration.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Configuration.dll</HintPath>
     </Reference>

--- a/XplorerPlugin.Bcf/packages.config
+++ b/XplorerPlugin.Bcf/packages.config
@@ -12,7 +12,6 @@
   <package id="Microsoft.Extensions.Logging.Abstractions" version="2.1.1" targetFramework="net47" />
   <package id="Microsoft.Extensions.Options" version="2.1.1" targetFramework="net47" />
   <package id="Microsoft.Extensions.Primitives" version="2.1.1" targetFramework="net47" />
-  <package id="SharpZipLib" version="1.1.0" targetFramework="net47" />
   <package id="System.Buffers" version="4.5.0" targetFramework="net47" />
   <package id="System.Configuration.ConfigurationManager" version="4.5.0" targetFramework="net47" />
   <package id="System.Memory" version="4.5.3" targetFramework="net47" />


### PR DESCRIPTION
Refactored plugin system to use DotnetZip to extract manifest

Rationale: one zip library not 2. NPOI (in Exchange) requires an older incompatible version of ICSharpZipLib