### PR TITLE
Feature to open references from Xplorer

### DIFF
--- a/Xbim.Presentation/IfcMetaDataControl.xaml
+++ b/Xbim.Presentation/IfcMetaDataControl.xaml
@@ -3,6 +3,11 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:Xbim.Presentation"           
              >
+
+    <UserControl.CommandBindings>
+        <CommandBinding Command="Open" Executed="OpenExternalLink"/> 
+    </UserControl.CommandBindings>
+    
     <UserControl.Resources>
         <Style TargetType="{x:Type Hyperlink}" x:Key="HyperlinkStyle">
             <EventSetter Event="RequestNavigate" Handler="Hyperlink_RequestNavigate"/>
@@ -19,7 +24,7 @@
 				          Unchecked="CheckBoxChanged">Verbose
                 </CheckBox>
                 <Button x:Name="BtnBack" IsEnabled="False" FontSize="8" Click="Back" Content="&lt;-" HorizontalAlignment="Right" Width="20" VerticalAlignment="Top" Height="15" Margin="3" />
-                <DataGrid ItemsSource="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type local:IfcMetaDataControl}}, Path=ObjectGroups}"
+                <DataGrid x:Name="dataGridObject" ItemsSource="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type local:IfcMetaDataControl}}, Path=ObjectGroups}"
 				          Margin="0,22,0,0"
 				          ToolTip="Attributes of the Object"
 				          AutoGenerateColumns="False"
@@ -84,6 +89,23 @@
 																			</Hyperlink>
 																		</TextBlock>
                                                                     </Grid>
+                                                                </ControlTemplate>
+                                                            </Setter.Value>
+                                                        </Setter>
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding Path=IsLink}"
+													             Value="true">
+                                                        <Setter Property="Template">
+                                                            <Setter.Value>
+                                                                <ControlTemplate>
+                                                                    <TextBlock Margin="2,0">
+																		<Hyperlink NavigateUri="{Binding Path=Value}"
+																			        Style="{Binding Source={StaticResource HyperlinkStyle}}" 
+                                                                                    Command="Open" 
+                                                                                    CommandParameter="{Binding Path=Value}">
+																			<TextBlock Text="{Binding Path=Value}"/>
+																		</Hyperlink>
+																	</TextBlock>
                                                                 </ControlTemplate>
                                                             </Setter.Value>
                                                         </Setter>

--- a/Xbim.Presentation/IfcMetaDataControl.xaml.cs
+++ b/Xbim.Presentation/IfcMetaDataControl.xaml.cs
@@ -844,5 +844,19 @@ namespace Xbim.Presentation
         }
 
         private readonly HistoryCollection<IPersistEntity> _history = new HistoryCollection<IPersistEntity>(20);
+
+        /// <summary>
+        /// Event for clicking on external hyperlink
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OpenExternalLink(object sender, System.Windows.Input.ExecutedRoutedEventArgs e)
+        {
+            string path = e.Parameter as string;
+            System.Diagnostics.Process uriApp = new System.Diagnostics.Process();
+            uriApp.StartInfo.FileName = path;
+            uriApp.Start();
+        }
+        
     }
 }


### PR DESCRIPTION
I've added the possibility to directly open external references from the Xplorer. This is done by extending the IfcMetaDataControl. For this purpose i have used the existing property IsLink from IfcMetaDataControl.PropertyItem. The visualization is similar to the implementation of the links to ifc entities. The second column has now three different DataTriggers: one for text, one for links to other IFC entities and one for external links. See IfcMetaDataControl line 96 to 112. Furthermore, the code behind contains an additional method namely OpenExternalLink to show the file on click. Hence, an pdf file is opened in the standard pdf viewer.