### PR TITLE
Representation context selection

### DIFF
--- a/Xbim.Presentation/DrawingControl3D.xaml.cs
+++ b/Xbim.Presentation/DrawingControl3D.xaml.cs
@@ -241,6 +241,8 @@ namespace Xbim.Presentation
 
         public List<IPersistEntity> HiddenInstances = null;
 
+        public List<IIfcGeometricRepresentationContext> SelectedContexts = null;
+
         private LinesVisual3D _userModeledDimLines;
         private PointsVisual3D _userModeledDimPoints;
         public PolylineGeomInfo UserModeledDimension = new PolylineGeomInfo();
@@ -1405,7 +1407,7 @@ namespace Xbim.Presentation
             XbimScene<WpfMeshGeometry3D, WpfMaterial> scene = null;
             if (! Model.GeometryStore.IsEmpty)
                 scene = DefaultLayerStyler.BuildScene(model.ReferencingModel, ModelPositions[model.ReferencingModel].Transform, Opaques, Transparents, 
-                    IsolateInstances, HiddenInstances, ExcludedTypes);
+                    IsolateInstances, HiddenInstances, SelectedContexts, ExcludedTypes);
 
             if (scene != null && scene.Layers.Any())
             {
@@ -1437,7 +1439,7 @@ namespace Xbim.Presentation
 
             XbimScene<WpfMeshGeometry3D, WpfMaterial> scene = null;
             if (!mod.GeometryStore.IsEmpty)
-                scene = DefaultLayerStyler.BuildScene(refModel.Model, pos, Opaques, Transparents, IsolateInstances, HiddenInstances, ExcludedTypes);
+                scene = DefaultLayerStyler.BuildScene(refModel.Model, pos, Opaques, Transparents, IsolateInstances, HiddenInstances, SelectedContexts, ExcludedTypes);
             if (scene != null && scene.Layers.Any())
             {
                 Scenes.Add(scene);

--- a/Xbim.Presentation/LayerStyling/BoundingBoxStyler.cs
+++ b/Xbim.Presentation/LayerStyling/BoundingBoxStyler.cs
@@ -51,6 +51,7 @@ namespace Xbim.Presentation.LayerStyling
             var excludedTypes = model.DefaultExclusions(excludeTypes);
             var onlyInstances = isolateInstances?.Where(i => i.Model == model).ToDictionary(i => i.EntityLabel);
             var hiddenInstances = hideInstances?.Where(i => i.Model == model).ToDictionary(i => i.EntityLabel);
+            var selectedContexts = selectContexts?.Where(i => i.Model == model).ToDictionary(i => i.EntityLabel);
 
             var scene = new XbimScene<WpfMeshGeometry3D, WpfMaterial>(model);
             var timer = new Stopwatch();
@@ -89,7 +90,8 @@ namespace Xbim.Presentation.LayerStyling
                     // !typeof(IfcSpace).IsAssignableFrom(IfcMetaData.GetType(s.IfcTypeId))*/);
                     foreach (var shapeInstance in shapeInstances
                         .Where(s => null == onlyInstances || onlyInstances.Count == 0 || onlyInstances.Keys.Contains(s.IfcProductLabel))
-                        .Where(s => null == hiddenInstances || hiddenInstances.Count == 0 || !hiddenInstances.Keys.Contains(s.IfcProductLabel)))
+                        .Where(s => null == hiddenInstances || hiddenInstances.Count == 0 || !hiddenInstances.Keys.Contains(s.IfcProductLabel))
+                        .Where(s => null == selectedContexts || selectedContexts.Count == 0 || selectedContexts.Keys.Contains(s.RepresentationContext)))
                     {
                         // logging 
                         var currentProgress = 100 * prog++ / tot;

--- a/Xbim.Presentation/LayerStyling/BoundingBoxStyler.cs
+++ b/Xbim.Presentation/LayerStyling/BoundingBoxStyler.cs
@@ -40,10 +40,13 @@ namespace Xbim.Presentation.LayerStyling
         /// <param name="transparentShapes"></param>
         /// <param name="isolateInstances">List of instances to be isolated</param>
         /// <param name="hideInstances">List of instances to be hidden</param>
+        /// <param name="selectContexts">Selected Contexts</param>
         /// <param name="excludeTypes">List of type to exclude, by default excplict openings and spaces are excluded if exclude = null</param>
         /// <returns></returns>
         public XbimScene<WpfMeshGeometry3D, WpfMaterial> BuildScene(IModel model, XbimMatrix3D modelTransform, 
-            ModelVisual3D opaqueShapes, ModelVisual3D transparentShapes, List<IPersistEntity> isolateInstances = null, List<IPersistEntity> hideInstances = null, List<Type> excludeTypes = null)
+            ModelVisual3D opaqueShapes, ModelVisual3D transparentShapes, List<IPersistEntity> isolateInstances = null, 
+            List<IPersistEntity> hideInstances = null, List<IIfcGeometricRepresentationContext> selectContexts = null,
+            List<Type> excludeTypes = null)
         {
             var excludedTypes = model.DefaultExclusions(excludeTypes);
             var onlyInstances = isolateInstances?.Where(i => i.Model == model).ToDictionary(i => i.EntityLabel);

--- a/Xbim.Presentation/LayerStyling/ILayerStyler.cs
+++ b/Xbim.Presentation/LayerStyling/ILayerStyler.cs
@@ -4,13 +4,16 @@ using System.Windows.Media.Media3D;
 using Xbim.Common;
 using Xbim.Common.Federation;
 using Xbim.Common.Geometry;
+using Xbim.Ifc4.Interfaces;
 
 namespace Xbim.Presentation.LayerStyling
 {
     public interface ILayerStyler
     {
         XbimScene<WpfMeshGeometry3D, WpfMaterial> BuildScene(IModel model, XbimMatrix3D modelTransform, 
-            ModelVisual3D opaqueShapes, ModelVisual3D transparentShapes, List<IPersistEntity> isolateInstances = null, List<IPersistEntity> hideInstances = null, List<Type> excludeTypes = null);
+            ModelVisual3D opaqueShapes, ModelVisual3D transparentShapes, List<IPersistEntity> isolateInstances = null, 
+            List<IPersistEntity> hideInstances = null, List<IIfcGeometricRepresentationContext> selectContexts = null, 
+            List<Type> excludeTypes = null);
         void SetFederationEnvironment(IReferencedModel refModel);
     }
 

--- a/Xbim.Presentation/LayerStyling/SurfaceLayerStyler.cs
+++ b/Xbim.Presentation/LayerStyling/SurfaceLayerStyler.cs
@@ -39,13 +39,17 @@ namespace Xbim.Presentation.LayerStyling
         /// <param name="isolateInstances">List of instances to be isolated</param>
         /// <param name="hideInstances">List of instances to be hidden</param>
         /// <param name="excludeTypes">List of type to exclude, by default excplict openings and spaces are excluded if exclude = null</param>
+        /// <param name="selectContexts">Contexts for displaying</param>
         /// <returns></returns>
         public XbimScene<WpfMeshGeometry3D, WpfMaterial> BuildScene(IModel model, XbimMatrix3D modelTransform, 
-            ModelVisual3D opaqueShapes, ModelVisual3D transparentShapes, List<IPersistEntity> isolateInstances = null, List<IPersistEntity> hideInstances = null, List<Type> excludeTypes = null)
+            ModelVisual3D opaqueShapes, ModelVisual3D transparentShapes, List<IPersistEntity> isolateInstances = null, 
+            List<IPersistEntity> hideInstances = null, List<IIfcGeometricRepresentationContext> selectContexts = null,
+            List <Type> excludeTypes = null)
         {
             var excludedTypes = model.DefaultExclusions(excludeTypes);
             var onlyInstances = isolateInstances?.Where(i => i.Model == model).ToDictionary(i => i.EntityLabel);
             var hiddenInstances = hideInstances?.Where(i => i.Model == model).ToDictionary(i => i.EntityLabel);
+            var selectedContexts = selectContexts?.Where(i => i.Model == model).ToDictionary(i => i.EntityLabel);
 
             var scene = new XbimScene<WpfMeshGeometry3D, WpfMaterial>(model);
             var timer = new Stopwatch();
@@ -85,7 +89,8 @@ namespace Xbim.Presentation.LayerStyling
                     // !typeof(IfcSpace).IsAssignableFrom(IfcMetaData.GetType(s.IfcTypeId))*/);
                     foreach (var shapeInstance in shapeInstances
                         .Where(s => null == onlyInstances || onlyInstances.Count == 0 || onlyInstances.Keys.Contains(s.IfcProductLabel) )
-                        .Where(s => null == hiddenInstances || hiddenInstances.Count == 0 || !hiddenInstances.Keys.Contains(s.IfcProductLabel) ))
+                        .Where(s => null == hiddenInstances || hiddenInstances.Count == 0 || !hiddenInstances.Keys.Contains(s.IfcProductLabel)) 
+                        .Where(s => null == selectedContexts || selectedContexts.Count == 0 || selectedContexts.Keys.Contains(s.RepresentationContext)))
                     {
                         // logging 
                         var currentProgress = 100 * prog++ / tot;

--- a/XbimXplorer/Dialogs/RepresentationContextSelection.xaml
+++ b/XbimXplorer/Dialogs/RepresentationContextSelection.xaml
@@ -1,0 +1,36 @@
+﻿<Window x:Class="XbimXplorer.Dialogs.RepresentationContextSelection"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:xBimDialogs="clr-namespace:XbimXplorer.Dialogs"
+        mc:Ignorable="d"
+        Title="Representation Context Selection" Height="450" Width="800"
+        DataContext="{Binding RelativeSource={RelativeSource Self}}">
+    <Window.CommandBindings>
+        <CommandBinding Command="ApplicationCommands.Close" Executed="AcknowledgeSelection"/>
+        <CommandBinding Command="ApplicationCommands.Stop" Executed="CancelSelection"/>
+    </Window.CommandBindings>
+    <Grid Margin="10">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="1*"/>
+            <ColumnDefinition Width="1*"/>
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="1*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <TreeView Grid.ColumnSpan="2" Grid.RowSpan="1" Grid.Row="0" Name="contextSelectionTreeView" ItemsSource="{Binding ContextItems}">
+            <TreeView.ItemTemplate>
+                <HierarchicalDataTemplate  DataType="{x:Type xBimDialogs:ContextSelectionItem}" ItemsSource="{Binding Children}">
+                    <StackPanel Orientation="Horizontal">
+                        <CheckBox IsChecked="{Binding IsChecked}"/>
+                        <TextBlock Text="{Binding Name}"/>
+                    </StackPanel>
+                </HierarchicalDataTemplate>
+            </TreeView.ItemTemplate>
+        </TreeView>
+        <Button Grid.Column="0" Grid.Row="2" HorizontalAlignment="Left" FontSize="20" Margin="5" Command="ApplicationCommands.Stop">Cancel</Button>
+        <Button Grid.Column="1" Grid.Row="2" HorizontalAlignment="Right" FontSize="20" Margin="5" Command="ApplicationCommands.Close">OK</Button>
+    </Grid>
+</Window>

--- a/XbimXplorer/Dialogs/RepresentationContextSelection.xaml
+++ b/XbimXplorer/Dialogs/RepresentationContextSelection.xaml
@@ -30,7 +30,7 @@
                 </HierarchicalDataTemplate>
             </TreeView.ItemTemplate>
         </TreeView>
-        <Button Grid.Column="0" Grid.Row="2" HorizontalAlignment="Left" FontSize="20" Margin="5" Command="ApplicationCommands.Stop">Cancel</Button>
-        <Button Grid.Column="1" Grid.Row="2" HorizontalAlignment="Right" FontSize="20" Margin="5" Command="ApplicationCommands.Close">OK</Button>
+        <Button Grid.Column="0" Grid.Row="2" Height="25" Width="80" HorizontalAlignment="Left" Margin="5" Command="ApplicationCommands.Stop">Cancel</Button>
+        <Button Grid.Column="1" Grid.Row="2" Height="25" Width="80" HorizontalAlignment="Right" Margin="5" Command="ApplicationCommands.Close">OK</Button>
     </Grid>
 </Window>

--- a/XbimXplorer/Dialogs/RepresentationContextSelection.xaml.cs
+++ b/XbimXplorer/Dialogs/RepresentationContextSelection.xaml.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows;
+using System.Linq;
+using Xbim.Ifc4.Interfaces;
+
+namespace XbimXplorer.Dialogs
+{
+    /// <summary>
+    /// Item for the context selection
+    /// </summary>
+    public class ContextSelectionItem : INotifyPropertyChanged
+    {
+        /// <summary>
+        /// implementation of INotifyPropertyChanged
+        /// </summary>
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <summary>
+        /// Child objects
+        /// </summary>
+        public ObservableCollection<ContextSelectionItem> Children { get; set; } 
+            = new ObservableCollection<ContextSelectionItem>();
+
+        /// <summary>
+        /// Reflects if this entity was checked
+        /// </summary>
+        public bool IsChecked
+        {
+            get { return _isChecked; }
+            set 
+            {
+                if (this._isChecked != value)
+                {
+                    _isChecked = value;
+                    this.OnPropertyChanged();
+                }
+                foreach (ContextSelectionItem child in Children)
+                {
+                    child.IsChecked = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// internal representation of isChecked
+        /// </summary>
+        private bool _isChecked;
+
+        /// <summary>
+        /// Included Context
+        /// </summary>
+        public IIfcGeometricRepresentationContext RepresentationContext { get; set; }
+
+        /// <summary>
+        /// Name of the context
+        /// </summary>
+        public string Name
+        {
+            get
+            {
+                return this.RepresentationContext.ContextIdentifier;
+            }
+        }
+
+        /// <summary>
+        /// empty constructor
+        /// </summary>
+        public ContextSelectionItem()
+        {
+
+        }
+
+        /// <summary>
+        /// Constructor with context as content
+        /// </summary>
+        /// <param name="content"></param>
+        public ContextSelectionItem(IIfcGeometricRepresentationContext content)
+        {
+            this.IsChecked = true;
+            this.RepresentationContext = content;
+            if (content.HasSubContexts != null)
+            {
+                foreach (IIfcGeometricRepresentationSubContext child in content.HasSubContexts)
+                {
+                    this.Children.Add(new ContextSelectionItem(child));
+                }
+            }
+        }
+
+        protected virtual void OnPropertyChanged([CallerMemberName]string propertyName = null)
+        {
+            this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+
+    /// <summary>
+    /// Interaktionslogik für MainWindow.xaml
+    /// </summary>
+    public partial class RepresentationContextSelection : Window
+    {
+        public ObservableCollection<ContextSelectionItem> ContextItems { get; set; } 
+            = new ObservableCollection<ContextSelectionItem>();
+
+        public RepresentationContextSelection()
+        {
+            InitializeComponent();
+        }
+
+        /// <summary>
+        /// Set the internal Collection of items
+        /// </summary>
+        /// <param name="items"></param>
+        public void SetContextItems(IEnumerable<IIfcGeometricRepresentationContext> items)
+        {
+            Dictionary<int,IIfcGeometricRepresentationContext> processedItems = new Dictionary<int,IIfcGeometricRepresentationContext>();
+            this.ContextItems.Clear();
+
+            foreach(IIfcGeometricRepresentationContext item in items)
+            {
+                if (processedItems.ContainsKey(item.EntityLabel) == false)
+                {
+                    ContextSelectionItem parent = new ContextSelectionItem(item);
+                    this.ContextItems.Add(parent);
+                    processedItems.Add(item.EntityLabel, item);
+                }
+            }
+        }
+
+        private void AcknowledgeSelection(object sender, System.Windows.Input.ExecutedRoutedEventArgs e)
+        {
+            this.DialogResult = true;
+            this.Close();
+        }
+
+        private void CancelSelection(object sender, System.Windows.Input.ExecutedRoutedEventArgs e)
+        {
+            this.DialogResult = false;
+            this.Close();
+        }
+    }
+}

--- a/XbimXplorer/XbimXplorer.csproj
+++ b/XbimXplorer/XbimXplorer.csproj
@@ -46,6 +46,7 @@
     <Resource Include="**\*.png" />
   </ItemGroup>
   <ItemGroup>
+    <None Remove="Dialogs\RepresentationContextSelection.xaml" />
     <None Remove="xBIM.ico" />
   </ItemGroup>
   <ItemGroup>
@@ -79,5 +80,10 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xbim.Presentation\Xbim.Presentation.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Page Update="Dialogs\RepresentationContextSelection.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
 </Project>

--- a/XbimXplorer/XplorerMainWindow.xaml
+++ b/XbimXplorer/XplorerMainWindow.xaml
@@ -118,6 +118,7 @@
                 <MenuItem Header="Isolate selected objects" Click="IsolateSelected"/>
                 <MenuItem Header="Hide selected objects" Click="HideSelected"/>
                 <MenuItem Header="Show all objects" Click="RestoreView"/>
+                <MenuItem Header="Select visualization context" Click="SelectRepresentationContext"/>
                 <Separator Visibility="{Binding DeveloperVisible, ElementName=MainWindow}" />
                 <MenuItem x:Name="DeveloperMenu" Header="_Developer windows" Visibility="{Binding DeveloperVisible, ElementName=MainWindow}" >
                     <MenuItem Header="IFC stripping" Click="OpenStrippingWindow">

--- a/XbimXplorer/XplorerMainWindow.xaml.cs
+++ b/XbimXplorer/XplorerMainWindow.xaml.cs
@@ -1071,7 +1071,35 @@ namespace XbimXplorer
         {
             DrawingControl.IsolateInstances = null;
             DrawingControl.HiddenInstances = null;
+            DrawingControl.SelectedContexts = null;
             DrawingControl.ReloadModel(DrawingControl3D.ModelRefreshOptions.ViewPreserveCameraPosition);
+        }
+
+        private void SelectRepresentationContext (object sender, RoutedEventArgs e)
+        {
+            RepresentationContextSelection w = new RepresentationContextSelection();
+            IEnumerable<IIfcGeometricRepresentationContext> availableContexts = this.Model.Instances.OfType<IIfcGeometricRepresentationContext>();
+            IEnumerable<IIfcGeometricRepresentationContext> availableParentContexts = availableContexts.Except(this.Model.Instances.OfType<IIfcGeometricRepresentationSubContext>());
+            w.SetContextItems(availableParentContexts);
+            if (w.ShowDialog() == true)
+            {
+                this.DrawingControl.SelectedContexts = new List<IIfcGeometricRepresentationContext>();
+                foreach (ContextSelectionItem parent in w.ContextItems)
+                {
+                    if (parent.IsChecked)
+                    {
+                        this.DrawingControl.SelectedContexts.Add(parent.RepresentationContext);
+                    }
+                    foreach (ContextSelectionItem child in parent.Children)
+                    {
+                        if (child.IsChecked)
+                        {
+                            this.DrawingControl.SelectedContexts.Add(child.RepresentationContext); 
+                        }
+                    }
+                }
+                this.DrawingControl.ReloadModel(DrawingControl3D.ModelRefreshOptions.ViewPreserveCameraPosition);
+            }
         }
 
         private void SelectionMode(object sender, RoutedEventArgs e)


### PR DESCRIPTION
See issue #136. I Have added the possibility to select the visualization context. A new entry in the view menu has been added "Select visualization context". A new dialog pops up and allows to select contexts and subcontexts. For the visualization I have adjusted the interface ILayerstyler and extended the method BuildScene with the selected contexts. Based on this, only the SurfaceLayerStyler has been changed to respect the visualization context. The same has to be done at the BoundingBoxLayerStyler.