### PR TITLE
Added GeometryLoaded event to DrawingControl3D (WPF)

### DIFF
--- a/Xbim.Presentation/DrawingControl3D.xaml.cs
+++ b/Xbim.Presentation/DrawingControl3D.xaml.cs
@@ -664,11 +664,13 @@ namespace Xbim.Presentation
 				: (modelHit.Instances[frag.EntityLabel]);
 		}
 
-		#endregion
+		public event EventHandler<EventArgs> GeometryLoaded;
 
-		#region Dependency Properties
+        #endregion
 
-		public double ModelOpacity
+        #region Dependency Properties
+
+        public double ModelOpacity
 		{
 			get { return (double)GetValue(ModelOpacityProperty); }
 			set { SetValue(ModelOpacityProperty, value); }
@@ -1518,6 +1520,8 @@ namespace Xbim.Presentation
 			}
 
 			RecalculateView(options);
+
+			GeometryLoaded?.Invoke(this, EventArgs.Empty);
 		}
 
 		private void LoadReferencedModel(IReferencedModel refModel)

--- a/Xbim.Presentation/Xbim.Presentation.csproj
+++ b/Xbim.Presentation/Xbim.Presentation.csproj
@@ -43,7 +43,7 @@
   <ItemGroup>
     <PackageReference Include="HelixToolkit.Wpf" Version="2.14.0" />
     <PackageReference Include="PropertyTools.Wpf.DeploymentClone" Version="0.0.1" />
-    <PackageReference Include="Xbim.Geometry" Version="5.1.443-develop" />
+    <PackageReference Include="Xbim.Geometry" Version="5.1.541" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/Xbim.WinformsSample/Xbim.WinformsSample.csproj
+++ b/Xbim.WinformsSample/Xbim.WinformsSample.csproj
@@ -49,8 +49,8 @@
 		<PackageReference Include="System.Security.Permissions" Version="4.5.0" />
 		<PackageReference Include="System.Security.Principal.Windows" Version="4.5.1" />
 		<PackageReference Include="System.Threading.Tasks" Version="4.3.0" />		
-		<PackageReference Include="Xbim.Geometry" Version="5.1.443-develop" />
-		<PackageReference Include="Xbim.IO.Esent" Version="5.1.350" />
+		<PackageReference Include="Xbim.Geometry" Version="5.1.541" />
+		<PackageReference Include="Xbim.IO.Esent" Version="6.0.445" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\Xbim.Presentation\Xbim.Presentation.csproj" />

--- a/XbimXplorer/Commands/wdwCommands.xaml.cs
+++ b/XbimXplorer/Commands/wdwCommands.xaml.cs
@@ -2813,9 +2813,9 @@ namespace XbimXplorer.Commands
                 ? " [#" + propLabel + "]" 
                 : ""
                 );
-            if (pe as Xbim.Ifc2x3.Interfaces.IIfcCartesianPoint != null)
+            if (pe as IIfcCartesianPoint != null)
             {
-                var n = pe as Xbim.Ifc2x3.Interfaces.IIfcCartesianPoint;
+                var n = pe as IIfcCartesianPoint;
                 var vals = n.Coordinates.Select(x => x.Value);
                 ret += "\t" + string.Join("\t,\t", vals);
             }

--- a/XbimXplorer/XbimXplorer.csproj
+++ b/XbimXplorer/XbimXplorer.csproj
@@ -62,8 +62,8 @@
 		<PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
 		<PackageReference Include="Serilog.Extensions.Logging" Version="2.0.4" />
 		<PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />
-		<PackageReference Include="Xbim.Geometry" Version="5.1.443-develop" />
-		<PackageReference Include="Xbim.IO.Esent" Version="5.1.350" />
+		<PackageReference Include="Xbim.Geometry" Version="5.1.541" />
+		<PackageReference Include="Xbim.IO.Esent" Version="6.0.445" />
 	</ItemGroup>
 	<ItemGroup>
 		<Reference Include="Microsoft.CSharp" />

--- a/XbimXplorer/XplorerMainWindow.xaml.cs
+++ b/XbimXplorer/XplorerMainWindow.xaml.cs
@@ -47,6 +47,9 @@ using Serilog.Events;
 using Xbim.IO;
 using Xbim.Geometry.Engine.Interop;
 using System.Windows.Media;
+using Xbim.Common.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
 
 #endregion
 
@@ -117,7 +120,7 @@ namespace XbimXplorer
         public XplorerMainWindow(bool preventPluginLoad = false)
         {
             // So we can use *.xbim files.
-            IfcStore.ModelProviderFactory.UseHeuristicModelProvider();
+            XbimServices.Current.ConfigureServices(s => s.AddXbimToolkit(opt => opt.AddHeuristicModel()));
             
             LogSink = new InMemoryLogSink { Tag = "MainWindow" };
             LogSink.Logged += LogEvent_Added;
@@ -138,7 +141,7 @@ namespace XbimXplorer
                 .Enrich.FromLogContext()
                 .CreateLogger();
             // Set XBIM Essentials/Geometries's LoggerFactory - so Serilog drives everything.
-            XbimLogging.LoggerFactory = LoggerFactory;
+            XbimServices.Current.ConfigureServices(s => s.AddSingleton(typeof(ILoggerFactory), LoggerFactory));
 
             Logger = LoggerFactory.CreateLogger<XplorerMainWindow>();
 

--- a/XplorerPlugin.Bcf/XplorerPlugin.Bcf.csproj
+++ b/XplorerPlugin.Bcf/XplorerPlugin.Bcf.csproj
@@ -68,6 +68,6 @@
     <PackageReference Include="System.Security.Permissions" Version="4.5.0" />
     <PackageReference Include="System.Security.Principal.Windows" Version="4.5.1" />
     <PackageReference Include="System.Threading.Tasks" Version="4.3.0" />
-    <PackageReference Include="Xbim.Geometry" Version="5.1.443-develop" />    
+    <PackageReference Include="Xbim.Geometry" Version="5.1.541" />    
   </ItemGroup>
 </Project>


### PR DESCRIPTION
IFC files with complex geometry can take a long time to load in the DrawingControl3D.
In my app I need to know when the 3D Viewer has finished loading the model.
I therefore created a simple event which is triggered after geometry has been loaded.

I found no other way to achieve this.