### PR TITLE
Compiling ok with xbim6 libraries.

### DIFF
--- a/Xbim.Presentation/DrawingControl3D.xaml.cs
+++ b/Xbim.Presentation/DrawingControl3D.xaml.cs
@@ -854,8 +854,6 @@ namespace Xbim.Presentation
 			return false;
 		}
 
-		
-
 		public IfcStore Model
 		{
 			get { return (IfcStore)GetValue(ModelProperty); }
@@ -1140,8 +1138,10 @@ namespace Xbim.Presentation
 			{
 				_lastSelectedProduct = newVal as IIfcProduct;
 			}
-
+			if (Model is null)
+				return new WpfMeshGeometry3D();
 			WpfMeshGeometry3D m;
+			var engine = Infrastructure.GetGeometryEngine(Model);
 			if (newVal is IIfcRepresentationItem)
 			{
 				if (_lastSelectedProduct == null)
@@ -1153,18 +1153,17 @@ namespace Xbim.Presentation
 					var selModel = _lastSelectedProduct.Model;
 					var modelTransform = ModelPositions[selModel].Transform;
 
-					m = WpfMeshGeometry3D.GetRepresentationGeometry(mat, productContexts, representationLabels, selModel, modelTransform, WcsAdjusted);
+					m = WpfMeshGeometry3D.GetRepresentationGeometry(mat, productContexts, representationLabels, selModel, modelTransform, WcsAdjusted, engine);
 					if (m.PositionCount == 0)
 					{
 						var gri = newVal as IIfcGeometricRepresentationItem;
 						if (gri != null)
 						{
-							var engine = new XbimGeometryEngine();
 							var solid = engine.Create(gri, null);
 							if (solid != null)
 							{
 								var shape = engine.CreateShapeGeometry(solid, selModel.ModelFactors.Precision, Model.ModelFactors.OneMetre / 20, selModel.ModelFactors.DeflectionAngle, XbimGeometryType.PolyhedronBinary, null);
-								m = WpfMeshGeometry3D.GetRepresentationGeometry2(mat, representationLabels, selModel, modelTransform, WcsAdjusted, shape, _lastSelectedProduct);
+								m = WpfMeshGeometry3D.GetRepresentationGeometry2(mat, representationLabels, selModel, modelTransform, WcsAdjusted, shape, _lastSelectedProduct, engine);
 							}
 						}
 					}
@@ -1172,7 +1171,7 @@ namespace Xbim.Presentation
 			}
 			else if (newVal is IIfcShapeRepresentation)
 			{
-				m = WpfMeshGeometry3D.GetGeometry((IIfcShapeRepresentation)newVal, ModelPositions, mat, WcsAdjusted);
+				m = WpfMeshGeometry3D.GetGeometry((IIfcShapeRepresentation)newVal, ModelPositions, mat, WcsAdjusted, engine);
 			}
 			else if (newVal is IIfcRelVoidsElement)
 			{
@@ -1180,7 +1179,7 @@ namespace Xbim.Presentation
 				var rep = vd.RelatedOpeningElement.Representation.Representations.OfType<IIfcShapeRepresentation>()
 					.FirstOrDefault();
 				if (rep != null)
-					m = WpfMeshGeometry3D.GetGeometry((IIfcShapeRepresentation)rep, ModelPositions, mat, WcsAdjusted);
+					m = WpfMeshGeometry3D.GetGeometry((IIfcShapeRepresentation)rep, ModelPositions, mat, WcsAdjusted, engine);
 				else
 				{
 					m = new WpfMeshGeometry3D();

--- a/Xbim.Presentation/FederatedModel/XbimReferencedModelViewModel.cs
+++ b/Xbim.Presentation/FederatedModel/XbimReferencedModelViewModel.cs
@@ -129,7 +129,7 @@ namespace Xbim.Presentation.FederatedModel
             if (_xbimReferencedModel.Model.GeometryStore.IsEmpty)
             {
                 var m3D = new Xbim3DModelContext(_xbimReferencedModel.Model);
-                m3D.CreateContext(adjustWcs: adjustWcs);
+                m3D.CreateContext(null, adjustWcs: adjustWcs);
             }
             
             if (_xbimReferencedModel == null) 

--- a/Xbim.Presentation/Infrastructure.cs
+++ b/Xbim.Presentation/Infrastructure.cs
@@ -1,0 +1,28 @@
+﻿#nullable enable
+using System;
+using Xbim.Common.Configuration;
+using Xbim.Geometry.Abstractions;
+using Xbim.Geometry.Engine.Interop;
+using Xbim.Ifc4.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Xbim.Presentation
+{
+	internal class Infrastructure
+	{
+		internal static IXbimGeometryEngine? GetGeometryEngine(Common.IModel? model)
+		{
+			if (model is null)
+				return null;
+			var geomFactory = XbimServices.Current.ServiceProvider.GetService<IXbimGeometryServicesFactory>();
+			var loggerFactory = XbimServices.Current.GetLoggerFactory();
+			if (geomFactory == null)
+			{
+				throw new InvalidOperationException("An implementation of IXbimGeometryServicesFactory could not be found.\n\nTo fix this add the following before calling any xbim functionality:\n\n XbimServices.Current.ConfigureServices(opt => opt.AddXbimToolkit(conf => conf.AddGeometryServices()));");
+			}
+			var _engine = geomFactory.CreateGeometryEngine(XGeometryEngineVersion.V6, model, loggerFactory);
+			return _engine;
+		}
+	}
+}
+#nullable restore

--- a/Xbim.Presentation/WpfMeshGeometry3D.cs
+++ b/Xbim.Presentation/WpfMeshGeometry3D.cs
@@ -101,20 +101,20 @@ namespace Xbim.Presentation
 
         // attempting to load the shapeGeometry from the database; 
         // 
-        public static WpfMeshGeometry3D GetGeometry(IIfcShapeRepresentation rep, XbimModelPositioningCollection positions, Material mat, bool wcsAdjust)
+        public static WpfMeshGeometry3D GetGeometry(IIfcShapeRepresentation rep, XbimModelPositioningCollection positions, Material mat, bool wcsAdjust, IXbimGeometryEngine eng)
         {
             var productContexts = rep.OfProductRepresentation?.OfType<IIfcProductDefinitionShape>().SelectMany(x => x.ShapeOfProduct);
             var representationLabels = rep.Items.Select(x => x.EntityLabel);
             var selModel = rep.Model;
             var modelTransform = positions[selModel].Transform;
 
-            return GetRepresentationGeometry(mat, productContexts, representationLabels, selModel, modelTransform, wcsAdjust);
+            return GetRepresentationGeometry(mat, productContexts, representationLabels, selModel, modelTransform, wcsAdjust, eng);
         }
+		
 
-
-        internal static WpfMeshGeometry3D GetRepresentationGeometry2(Material mat, IEnumerable<int> representationLabels, IModel selModel, XbimMatrix3D modelTransform, bool wcsAdjust, XbimShapeGeometry shapegeom, IIfcProduct contextualProduct)
+        internal static WpfMeshGeometry3D GetRepresentationGeometry2(Material mat, IEnumerable<int> representationLabels, IModel selModel, XbimMatrix3D modelTransform, bool wcsAdjust, XbimShapeGeometry shapegeom, IIfcProduct contextualProduct, IXbimGeometryEngine engine)
         {
-            var placementTree = new XbimPlacementTree(selModel, wcsAdjust);
+            var placementTree = new XbimPlacementTree(selModel, engine, wcsAdjust);
             var trsf = placementTree[contextualProduct.ObjectPlacement.EntityLabel];
             var tgt = new WpfMeshGeometry3D(mat, mat);
             tgt.BeginUpdate();
@@ -138,9 +138,9 @@ namespace Xbim.Presentation
 
         // attempting to load the shapeGeometry from the database; 
         // 
-        internal static WpfMeshGeometry3D GetRepresentationGeometry(Material mat, IEnumerable<IIfcProduct> productContexts, IEnumerable<int> representationLabels, IModel selModel, XbimMatrix3D modelTransform, bool wcsAdjust)
+        internal static WpfMeshGeometry3D GetRepresentationGeometry(Material mat, IEnumerable<IIfcProduct> productContexts, IEnumerable<int> representationLabels, IModel selModel, XbimMatrix3D modelTransform, bool wcsAdjust, IXbimGeometryEngine eng)
         {
-            var placementTree = new XbimPlacementTree(selModel, wcsAdjust);
+            var placementTree = new XbimPlacementTree(selModel, eng, wcsAdjust);
             var tgt = new WpfMeshGeometry3D(mat, mat);
             tgt.BeginUpdate();
             using (var geomstore = selModel.GeometryStore)

--- a/Xbim.Presentation/Xbim.Presentation.csproj
+++ b/Xbim.Presentation/Xbim.Presentation.csproj
@@ -11,6 +11,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageIcon>XbimIcon.png</PackageIcon>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net472|AnyCPU'">
     <OutputPath>..\Output\Debug\</OutputPath>
@@ -42,7 +43,8 @@
   <ItemGroup>
     <PackageReference Include="HelixToolkit.Wpf" Version="2.14.0" />
     <PackageReference Include="PropertyTools.Wpf.DeploymentClone" Version="0.0.1" />
-    <PackageReference Include="Xbim.Geometry" Version="5.1.782-develop" />
+    <PackageReference Include="Xbim.Geometry" Version="6.1.816-netcore" />
+    <PackageReference Include="Xbim.IO.Esent" Version="6.0.503-develop" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/Xbim.WinformsSample/Xbim.WinformsSample.csproj
+++ b/Xbim.WinformsSample/Xbim.WinformsSample.csproj
@@ -40,17 +40,9 @@
 		<PackageReference Include="Microsoft.Extensions.Primitives" Version="2.1.1" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 		<PackageReference Include="System.Buffers" Version="4.5.1" />
-		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
-		<PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
 		<PackageReference Include="System.Memory" Version="4.5.4" />
-		<PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
-		<PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.3" />
-		<PackageReference Include="System.Security.AccessControl" Version="4.5.0" />
-		<PackageReference Include="System.Security.Permissions" Version="4.5.0" />
-		<PackageReference Include="System.Security.Principal.Windows" Version="4.5.1" />
-		<PackageReference Include="System.Threading.Tasks" Version="4.3.0" />		
-		<PackageReference Include="Xbim.Geometry" Version="5.1.782-develop" />
-		<PackageReference Include="Xbim.IO.Esent" Version="6.0.484-develop" />
+		<PackageReference Include="Xbim.Geometry" Version="6.1.816-netcore" />
+		<PackageReference Include="Xbim.IO.Esent" Version="6.0.503-develop" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\Xbim.Presentation\Xbim.Presentation.csproj" />

--- a/XbimXplorer/App.xaml.cs
+++ b/XbimXplorer/App.xaml.cs
@@ -16,6 +16,8 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Windows;
+using Xbim.Common.Configuration;
+using Xbim.Geometry.Abstractions;
 using Xbim.IO;
 using XbimXplorer.Properties;
 
@@ -24,7 +26,7 @@ using XbimXplorer.Properties;
 namespace XbimXplorer
 {
     /// <summary>
-    ///   Interaction logic for App.xaml
+    /// Interaction logic for App.xaml
     /// </summary>
     public partial class App
     {
@@ -42,8 +44,14 @@ namespace XbimXplorer
         /// <param name="e">A <see cref="T:System.Windows.StartupEventArgs"/> that contains the event data.</param>
         protected override void OnStartup(StartupEventArgs e)
         {
-            // evaluate special parameters before loading MainWindow
-            var blockPlugin = false;
+			XbimServices.Current.ConfigureServices(services => services
+							.AddXbimToolkit(opt => opt
+								// .AddLoggerFactory(_loggerFactory)
+								// .AddEsentModel()
+								.AddHeuristicModel()
+								.AddGeometryServices(builder => builder.Configure(c => c.GeometryEngineVersion = XGeometryEngineVersion.V6))));
+			// evaluate special parameters before loading MainWindow
+			var blockPlugin = false;
             foreach (var thisArg in e.Args)
             {
                 if (string.Compare("/noplugins", thisArg, StringComparison.OrdinalIgnoreCase) == 0)
@@ -61,7 +69,7 @@ namespace XbimXplorer
                 Settings.Default.SettingsUpdateRequired = false;
                 Settings.Default.Save();
             }
-
+			// blockPlugin = true;
             var mainView = new XplorerMainWindow(blockPlugin);
             mainView.Show();
             mainView.DrawingControl.ViewHome();

--- a/XbimXplorer/Commands/wdwCommands.xaml.cs
+++ b/XbimXplorer/Commands/wdwCommands.xaml.cs
@@ -36,6 +36,9 @@ using Microsoft.Extensions.Logging;
 using Xbim.Common.ExpressValidation;
 using Xbim.Presentation.Overlay;
 using HelixToolkit.Wpf;
+using Xbim.Ifc4x3;
+using Xbim.Ifc4;
+using Xbim.Ifc2x3;
 
 // todo: see if gemini is a good candidate for a network based ui experience in xbim.
 // https://github.com/tgjones/gemini
@@ -807,7 +810,7 @@ namespace XbimXplorer.Commands
 			var labels = GetSelection(m).ToArray();
 			if (labels.Any())
 			{
-				var engine = new XbimGeometryEngine();
+				var engine = Infrastructure.GetGeometryEngine(Model);
 				foreach (var label in labels)
 				{
 					var entity = Model.Instances[label];
@@ -1016,8 +1019,11 @@ namespace XbimXplorer.Commands
 		private void ProcessBrepCommand(Match m)
 		{
 			FileInfo fi = new FileInfo(Model.FileName);
+
+			var engine = Infrastructure.GetGeometryEngine(Model);
+
 			var dirName = fi.DirectoryName;
-			XbimPlacementTree pt = new XbimPlacementTree(Model, App.ContextWcsAdjustment);
+			XbimPlacementTree pt = new XbimPlacementTree(Model, engine, App.ContextWcsAdjustment);
 			// add "DBRep_DrawableShape" as first line
 			var start = m.Groups["entities"].Value;
 			IEnumerable<int> labels = ToIntarray(start, ',');
@@ -1037,18 +1043,18 @@ namespace XbimXplorer.Commands
 					if (entity is IIfcProduct)
 					{
 						var prod = (IIfcProduct)entity;
-						trsf = XbimPlacementTree.GetTransform(prod, pt, new XbimGeometryEngine());
+						trsf = XbimPlacementTree.GetTransform(prod, pt, engine);
 						entities.Clear();
 						entities.AddRange(prod.Representation?.Representations.SelectMany(x => x.Items));
 					}
 					else if (entity is IIfcRelVoidsElement)
 					{
 						var prod = ((IIfcRelVoidsElement)entity).RelatedOpeningElement;
-						trsf = XbimPlacementTree.GetTransform(prod, pt, new XbimGeometryEngine());
+						trsf = XbimPlacementTree.GetTransform(prod, pt, engine);
 						entities.Clear();
 						entities.AddRange(prod.Representation?.Representations.SelectMany(x => x.Items));
 					}
-					var engine = new XbimGeometryEngine();
+					
 					var ifcFile = ((IfcStore)Model).FileName;
 					foreach (var solEntity in entities)
 					{
@@ -1345,14 +1351,15 @@ namespace XbimXplorer.Commands
             {
                 if (ModelIsUnavailable) 
                     return;
+				var engine = Infrastructure.GetGeometryEngine(Model);
                 var msg = "";
                 var storName = m.Groups["StoreyName"].Value;
                 var storey =
                     Model.Instances.OfType<IIfcBuildingStorey>().FirstOrDefault(x => x.Name == storName);
                 if (storey != null)
                 {
-                    var placementTree = new XbimPlacementTree(storey.Model, App.ContextWcsAdjustment);
-                    var trsf = XbimPlacementTree.GetTransform(storey, placementTree, new XbimGeometryEngine());
+                    var placementTree = new XbimPlacementTree(storey.Model, engine, App.ContextWcsAdjustment);
+                    var trsf = XbimPlacementTree.GetTransform(storey, placementTree, engine);
                     var off = trsf.OffsetZ;
                     var pt = new XbimPoint3D(0, 0, off);
 
@@ -1606,7 +1613,7 @@ namespace XbimXplorer.Commands
             Execute();
         }
 
-        private IEnumerable<(string methodName, List<IXbimSolid> solids)> GetSolidsByAvailableMethods(IPersistEntity entity, XbimGeometryEngine engine)
+        private IEnumerable<(string methodName, List<IXbimSolid> solids)> GetSolidsByAvailableMethods(IPersistEntity entity, IXbimGeometryEngine engine)
         {
             // todo: cache methods by type
             var methods = typeof(XbimGeometryEngine).GetMethods(BindingFlags.Public | BindingFlags.Instance);
@@ -2379,13 +2386,9 @@ namespace XbimXplorer.Commands
             }
         }
 
-        internal static Dictionary<string, ExpressMetaData> SchemaMetadatas => new Dictionary<string, ExpressMetaData>
-        {
-            {"ifc2x3", ExpressMetaData.GetMetadata(typeof(Xbim.Ifc2x3.SharedBldgElements.IfcWall).Module)},
-            {"ifc4", ExpressMetaData.GetMetadata(typeof(Xbim.Ifc4.SharedBldgElements.IfcWall).Module)}
-        };
+		internal static Dictionary<string, ExpressMetaData> SchemaMetadatas => Infrastructure.SchemaMetadatas;
 
-        private TextHighliter ReportType(string type, int beVerbose, string indentationHeader = "")
+		private TextHighliter ReportType(string type, int beVerbose, string indentationHeader = "")
         {
             Debug.WriteLine(type);
             var tarr = type.Split(new[] {"."}, StringSplitOptions.RemoveEmptyEntries);

--- a/XbimXplorer/Dialogs/ExcludedTypes/StylerConfiguration.xaml.cs
+++ b/XbimXplorer/Dialogs/ExcludedTypes/StylerConfiguration.xaml.cs
@@ -33,17 +33,15 @@ namespace XbimXplorer.Dialogs.ExcludedTypes
         {
             TypesTree.Items.Clear();
 
-            // this is done through the metadata in order to ensure that class relationships are loaded
-            var module4 = (typeof(Xbim.Ifc4.Kernel.IfcProduct)).Module;
-            var meta4 = ExpressMetaData.GetMetadata(module4);
-            var product4 = meta4.ExpressType("IFCPRODUCT");
-            TypesTree.Items.Add(new ObjectViewModel() { Header = "Ifc4.IfcProduct", Tag = new ExpressTypeExpander(product4, Model), IsChecked = true });
+			foreach (var item in Infrastructure.SchemaMetadatas)
+			{
+				var schemaVersion = item.Key;
+				var meta = item.Value;
 
-            // this is done through the metadata in order to ensure that class relationships are loaded
-            var module2X3 = (typeof(Xbim.Ifc2x3.Kernel.IfcProduct)).Module;
-            var meta2X3 = ExpressMetaData.GetMetadata(module2X3);
-            var product2X3 = meta2X3.ExpressType("IFCPRODUCT"); 
-            TypesTree.Items.Add(new ObjectViewModel() { Header = "Ifc2x3.IfcProduct", Tag = new ExpressTypeExpander(product2X3, Model), IsChecked = true });
+				// this is done through the metadata in order to ensure that class relationships are loaded
+				var product4 = meta.ExpressType("IFCPRODUCT");
+				TypesTree.Items.Add(new ObjectViewModel() { Header = $"{schemaVersion}.IfcProduct", Tag = new ExpressTypeExpander(product4, Model), IsChecked = true });
+			}
         }
 
         public List<Type> ExcludedTypes

--- a/XbimXplorer/Infrastructure.cs
+++ b/XbimXplorer/Infrastructure.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xbim.Common.Configuration;
+using Xbim.Common.Metadata;
+using Xbim.Geometry.Abstractions;
+using Xbim.Geometry.Engine.Interop;
+using Xbim.Ifc2x3;
+using Xbim.Ifc4;
+using Xbim.Ifc4.Interfaces;
+using Xbim.Ifc4x3;
+
+namespace XbimXplorer
+{
+	internal class Infrastructure
+	{
+		internal static Dictionary<string, ExpressMetaData> SchemaMetadatas => new Dictionary<string, ExpressMetaData>
+		{
+			{"ifc2x3", ExpressMetaData.GetMetadata(new EntityFactoryIfc2x3())},
+			{"ifc4", ExpressMetaData.GetMetadata(new EntityFactoryIfc4())},
+			{"ifc4x3", ExpressMetaData.GetMetadata(new EntityFactoryIfc4x3Add2())}
+		};
+
+		internal static IXbimGeometryEngine GetGeometryEngine(Xbim.Common.IModel model)
+		{
+			var geomFactory = XbimServices.Current.ServiceProvider.GetService<IXbimGeometryServicesFactory>();
+			var loggerFactory = XbimServices.Current.GetLoggerFactory();
+			if (geomFactory == null)
+			{
+				throw new InvalidOperationException("An implementation of IXbimGeometryServicesFactory could not be found.\n\nTo fix this add the following before calling any xbim functionality:\n\n XbimServices.Current.ConfigureServices(opt => opt.AddXbimToolkit(conf => conf.AddGeometryServices()));");
+			}
+
+			var _engine = geomFactory.CreateGeometryEngine(XGeometryEngineVersion.V6, model, loggerFactory);
+			return _engine;
+		}
+	}
+}

--- a/XbimXplorer/XbimEnvironment.cs
+++ b/XbimXplorer/XbimEnvironment.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Win32;
+
+namespace Xbim.ModelGeometry
+{
+    public static class XbimEnvironment
+    {
+        /// <summary>
+        /// Tests if the requierd VC++ redist platform is installed for the current execution environment.
+        /// </summary>
+        /// <returns>true if installed</returns>
+        public static bool RedistInstalled(bool? overrideUse64Bit = null)
+        {
+            var use64 = Is64BitProcess();
+            if (overrideUse64Bit.HasValue)
+                use64 = overrideUse64Bit.Value;
+
+            var substring = use64
+                ? "x64"
+                : "x86";
+
+            return InstalledRuntimes().Any(x => x.Contains(substring));
+        }
+
+        /// <summary>
+        /// Suggests the relevant download URL for the required C++ redistributable setup.
+        /// </summary>
+        /// <returns>a string pointing to the relevant executable</returns>
+        public static string RedistDownloadPath()
+        {
+            // information taken from
+            // http://stackoverflow.com/questions/12206314/detect-if-visual-c-redistributable-for-visual-studio-2012-is-installed/34209692#34209692
+
+            return Is64BitProcess()
+                ? @"https://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x64.exe"
+                : @"https://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x86.exe";
+        }
+        
+        /// <summary>
+        /// Tests for vc2013 redist installation through the registry
+        /// </summary>
+        /// <returns>A list of matching installations</returns>
+        public static IEnumerable<string> InstalledRuntimes()
+        {
+            var t2 = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Default);
+            var t3 = t2.OpenSubKey(@"SOFTWARE\Classes\Installer\Dependencies");
+            if (t3 == null)
+                yield break;
+
+            foreach (var subKeyName in t3.GetSubKeyNames())
+            {
+                var t4 = t3.OpenSubKey(subKeyName);
+                // ReSharper disable once UseNullPropagation
+                if (t4 == null)
+                    continue;
+                var t5 = t4.GetValue(@"DisplayName");
+                // ReSharper disable once UseNullPropagation
+                if (t5 == null)
+                    continue;
+                var s = t5 as string;
+                if (s == null)
+                    continue;
+                if (s.Contains(@"Microsoft Visual C++ 2013 Redistributable"))
+                {
+                    yield return s;
+                }
+            }
+        }
+
+        /// <summary>
+        /// The function used by the underlying interop library to determin what C++ assembly to load.
+        /// </summary>
+        /// <returns>true for 64 bit environments</returns>
+        public static bool Is64BitProcess()
+        {
+            return (IntPtr.Size == 8);
+        }
+    }
+}

--- a/XbimXplorer/XbimXplorer.csproj
+++ b/XbimXplorer/XbimXplorer.csproj
@@ -64,8 +64,7 @@
 		<PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
 		<PackageReference Include="Serilog.Extensions.Logging" Version="2.0.4" />
 		<PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />
-		<PackageReference Include="Xbim.Geometry" Version="5.1.782-develop" />
-		<PackageReference Include="Xbim.IO.Esent" Version="6.0.484-develop" />
+		<PackageReference Include="Xbim.IO.Esent" Version="6.0.503-develop" />
 	</ItemGroup>
 	<ItemGroup>
 		<Reference Include="Microsoft.CSharp" />

--- a/XbimXplorer/XplorerMainWindow.xaml.cs
+++ b/XbimXplorer/XplorerMainWindow.xaml.cs
@@ -254,8 +254,6 @@ namespace XbimXplorer
             ModelProvider.ObjectInstance = model;
             ModelProvider.Refresh();
 
-            
-
             TestCRedist();
         }
 
@@ -1174,20 +1172,8 @@ namespace XbimXplorer
 
         private void StylerIfcSpacesOnly(object sender, RoutedEventArgs e)
         {
-            var module2X3 = (typeof(Xbim.Ifc2x3.Kernel.IfcProduct)).Module;
-            var meta2X3 = ExpressMetaData.GetMetadata(module2X3);
-            var product2X3 = meta2X3.ExpressType("IFCPRODUCT");
-
-            var module4 = (typeof(Xbim.Ifc4.Kernel.IfcProduct)).Module;
-            var meta4 = ExpressMetaData.GetMetadata(module4);
-            var product4 = meta4.ExpressType("IFCPRODUCT");
-            
-
-
-            var tpcoll = product2X3.NonAbstractSubTypes.Select(x => x.Type).ToList();
-            tpcoll.AddRange(product4.NonAbstractSubTypes.Select(x => x.Type).ToList());
-            tpcoll.RemoveAll(x => x.Name == "IfcSpace");
-
+			var tpcoll = Infrastructure.SchemaMetadatas.Values.SelectMany(x => x.ExpressType("IFCPRODUCT").NonAbstractSubTypes.Select(y => y.Type)).ToList();
+            tpcoll.RemoveAll(x => x.Name.ToLower() == "ifcspace");
             DrawingControl.ExcludedTypes = tpcoll;
             DrawingControl.ReloadModel(DrawingControl3D.ModelRefreshOptions.ViewPreserveCameraPosition);
         }

--- a/XbimXplorer/app.config
+++ b/XbimXplorer/app.config
@@ -47,26 +47,4 @@
       </setting>
     </XbimXplorer.Properties.Settings>
   </userSettings>
-  <runtime>
-
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-
-      <dependentAssembly>
-
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-
-        <bindingRedirect oldVersion="0.0.0.0-2.1.1.0" newVersion="2.1.1.0" />
-
-      </dependentAssembly>
-
-      <dependentAssembly>
-
-        <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="adb9793829ddae60" culture="neutral" />
-
-        <bindingRedirect oldVersion="0.0.0.0-2.1.1.0" newVersion="2.1.1.0" />
-
-      </dependentAssembly>
-
-    </assemblyBinding>
-  </runtime>
 </configuration>

--- a/XplorerPlugin.Bcf/App.config
+++ b/XplorerPlugin.Bcf/App.config
@@ -33,30 +33,6 @@
         <assemblyIdentity name="NPOI" publicKeyToken="0df73ec7942b34e1" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.1.3.0" newVersion="2.1.3.0" />
       </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.1.0" newVersion="2.1.1.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.4.1" newVersion="4.0.4.1" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.1.0" newVersion="2.1.1.0" />
-      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/XplorerPlugin.Bcf/BCFFile.cs
+++ b/XplorerPlugin.Bcf/BCFFile.cs
@@ -1,9 +1,9 @@
-﻿using Ionic.Zip;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -14,28 +14,23 @@ namespace Xbim.BCF
     public class BcfFile 
     {
         public ObservableCollection<BcfInstance> Instances = new ObservableCollection<BcfInstance>();
-
         private const string MarkupFileName = "markup.bcf";
         private const string ViewpointFileName = "viewpoint.bcfv";
         private const string SnapshotFileName = "snapshot.png";
 
-
         public void LoadFile(string fileName)
         {
             // BCFFile retFile = new BCFFile();
-            using (ZipFile z = ZipFile.Read(fileName))
+            using (var z = ZipFile.OpenRead(fileName))
             {
                 Regex r = new Regex(@"(?<guid>.*?)/(?<fname>.*)");
-                foreach (var zipentry in z)
+                foreach (var zipentry in z.Entries)
                 {
                     string tFName = System.IO.Path.GetTempFileName();
-                    var res = r.Match(zipentry.FileName);
+                    var res = r.Match(zipentry.FullName);
                     if (res.Success)
                     {
-                        using (BinaryWriter writer = new BinaryWriter(File.Open(tFName, FileMode.Create)))
-                        {
-                            zipentry.Extract(writer.BaseStream);
-                        }
+						zipentry.ExtractToFile(tFName);
 
                         string guid = res.Groups["guid"].Value;
                         string fname = res.Groups["fname"].Value;
@@ -77,22 +72,43 @@ namespace Xbim.BCF
 
         internal void SaveFile(string filename)
         {
-            using (ZipFile zip = new ZipFile())
-            {
-                foreach (var instance in Instances)
-                {
-                    string dir = GetTemporaryDirectory(instance.Guid);
-                    instance.Markup.SaveToFile(Path.Combine(dir, MarkupFileName));
-                    instance.SnapShotSaveToFile(Path.Combine(dir, SnapshotFileName));
-                    instance.VisualizationInfo.SaveToFile(Path.Combine(dir, ViewpointFileName));
-                    zip.AddDirectory(dir, instance.Guid);
-                }
-                zip.Save(filename);
-                foreach (var instance in Instances)
-                {
-                    Directory.Delete(GetTemporaryDirectory(instance.Guid), true);
-                }
-            }
+			using (FileStream streamToOpen = new FileStream(filename, FileMode.CreateNew))
+			{
+				using ZipArchive archive = new ZipArchive(streamToOpen, ZipArchiveMode.Update);
+
+				foreach (var instance in Instances)
+				{
+					string dir = GetTemporaryDirectory(instance.Guid);
+					instance.Markup.SaveToFile(Path.Combine(dir, MarkupFileName));
+					instance.SnapShotSaveToFile(Path.Combine(dir, SnapshotFileName));
+					instance.VisualizationInfo.SaveToFile(Path.Combine(dir, ViewpointFileName));
+					AddDirectory(archive, dir, instance.Guid);
+				}
+				
+				foreach (var instance in Instances)
+				{
+					Directory.Delete(GetTemporaryDirectory(instance.Guid), true);
+				}
+			}
         }
-    }
+
+		private void AddDirectory(ZipArchive archive, string sourceDirectory, string entryName)
+		{
+			var directoryInfo = new DirectoryInfo(sourceDirectory);
+
+			// Add all files in the directory
+			foreach (var file in directoryInfo.GetFiles())
+			{
+				string entryPath = Path.Combine(entryName, file.Name);
+				archive.CreateEntryFromFile(file.FullName, entryPath);
+			}
+
+			// Recursively add subdirectories
+			foreach (var subDirectory in directoryInfo.GetDirectories())
+			{
+				string subDirectoryEntryName = Path.Combine(entryName, subDirectory.Name);
+				AddDirectory(archive, subDirectory.FullName, subDirectoryEntryName);
+			}
+		}
+	}
 }

--- a/XplorerPlugin.Bcf/XplorerPlugin.Bcf.csproj
+++ b/XplorerPlugin.Bcf/XplorerPlugin.Bcf.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <OutputType>WinExe</OutputType>
+    <LangVersion>latest</LangVersion>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -48,30 +49,10 @@
     <ProjectReference Include="..\Xbim.Presentation\Xbim.Presentation.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="DotNetZip" Version="1.13.3" />
     <PackageReference Include="HelixToolkit" Version="2.14.0" />
     <PackageReference Include="HelixToolkit.Wpf" Version="2.14.0" />
     <PackageReference Include="ManagedEsent" Version="1.9.4" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Primitives" Version="2.1.1" />
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
-    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="System.Memory" Version="4.5.4" />
-    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.3" />
-    <PackageReference Include="System.Security.AccessControl" Version="4.5.0" />
-    <PackageReference Include="System.Security.Permissions" Version="4.5.0" />
-    <PackageReference Include="System.Security.Principal.Windows" Version="4.5.1" />
-    <PackageReference Include="System.Threading.Tasks" Version="4.3.0" />
-    <PackageReference Include="Xbim.Geometry" Version="5.1.782-develop" />    
+    <PackageReference Include="System.IO.Compression" Version="4.3.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Hi @andyward,

I had a little time tonight and updated windowsUI to xbim6, retaining the net472 framework, but removing the vulnerable zip library.
I haven't tested it much, but it compiles and seems to load ifc and xbim files.

Do you think it's useful to merge this to develop? I think we could be releasing a new version that auto-updates with net472 before releasing a net6 or net8 version. 

Any thoughts?
Claudio